### PR TITLE
Fix/remove bump requirements

### DIFF
--- a/docker/stub/requirements.txt
+++ b/docker/stub/requirements.txt
@@ -1,44 +1,26 @@
 # API framework
-connexion==2.14.1
-Flask==2.2.2
+connexion==2.14.2
+Flask==2.2.3
 Flask-Cors==3.0.10
-itsdangerous==2.1.2
-jsonschema==4.15.0
-Markdown==3.4.1
-MarkupSafe==2.1.1
-pyyaml==6.0
-requests==2.28.1
-swagger-spec-validator==2.7.6
-tinydb==4.7.0
-urllib3==1.26.12
-Werkzeug==2.2.2
+tinydb==4.7.1
+Werkzeug==2.2.3
 
 # Misc utils
-setuptools==65.3.0
-certifi==2022.5.18.1
-absl-py==1.2.0
-chardet==3.0.4
-click==8.1.3
-clickclick==20.10.2
-gast==0.5.3
-idna==3.3
-pybind11==2.10.0
-inflection==0.5.1
+setuptools==67.4.0
 event-channel==0.4.3
-pytz==2022.2.1
+
+# IO extensions
+spidev==3.5
 
 # Audio
 sox==1.4.1
 
 # Computer Vision
 grpcio==1.48.1
-numpy==1.23.2
-Pillow==9.2.0
-protobuf==4.21.8
+numpy==1.24.2
+Pillow==9.4.0
+protobuf==4.22.0
 opencv-contrib-python==4.5.5.62
-tflite-runtime==2.10.0
+tflite-runtime==2.11.0
 pytesseract==0.3.10
 pyzbar==0.1.9
-
-#I/O
-spidev==3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,31 @@
 # API framework
-connexion==2.14.1
-Flask==2.2.2
+connexion==2.14.2
+Flask==2.2.3
 Flask-Cors==3.0.10
-itsdangerous==2.1.2
-jsonschema==4.15.0
-Markdown==3.4.1
-MarkupSafe==2.1.1
-pyyaml==6.0
-requests==2.28.1
-swagger-spec-validator==2.7.6
-tinydb==4.7.0
-urllib3==1.26.12
-Werkzeug==2.2.2
+#itsdangerous==2.1.2
+#jsonschema==4.15.0
+#Markdown==3.4.1
+#MarkupSafe==2.1.1
+#pyyaml==6.0
+#requests==2.28.1
+#swagger-spec-validator==2.7.6
+tinydb==4.7.1
+#urllib3==1.26.12
+Werkzeug==2.2.3
 
 # Misc utils
-setuptools==65.3.0
-certifi==2022.5.18.1
-absl-py==1.2.0
-chardet==3.0.4
-click==8.1.3
-clickclick==20.10.2
-gast==0.5.3
-idna==3.3
-pybind11==2.10.0
-inflection==0.5.1
+setuptools==67.4.0
+#certifi==2022.5.18.1
+#absl-py==1.2.0
+#chardet==3.0.4
+#click==8.1.3
+#clickclick==20.10.2
+#gast==0.5.3
+#idna==3.3
+#pybind11==2.10.0
+#inflection==0.5.1
 event-channel==0.4.3
-pytz==2022.2.1
+#pytz==2022.2.1
 
 # IO extensions
 pigpio==1.78

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,11 +39,11 @@ pyalsaaudio==0.9.2
 
 # Computer Vision
 grpcio==1.48.1
-numpy==1.23.2
-Pillow==9.2.0
-protobuf==4.21.8
+numpy==1.24.2
+Pillow==9.4.0
+protobuf==4.22.0
 opencv-contrib-python==4.5.5.62
-tflite-runtime==2.10.0
+tflite-runtime==2.11.0
 pytesseract==0.3.10
 picamera==1.13
 pyzbar==0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,30 +2,12 @@
 connexion==2.14.2
 Flask==2.2.3
 Flask-Cors==3.0.10
-#itsdangerous==2.1.2
-#jsonschema==4.15.0
-#Markdown==3.4.1
-#MarkupSafe==2.1.1
-#pyyaml==6.0
-#requests==2.28.1
-#swagger-spec-validator==2.7.6
 tinydb==4.7.1
-#urllib3==1.26.12
 Werkzeug==2.2.3
 
 # Misc utils
 setuptools==67.4.0
-#certifi==2022.5.18.1
-#absl-py==1.2.0
-#chardet==3.0.4
-#click==8.1.3
-#clickclick==20.10.2
-#gast==0.5.3
-#idna==3.3
-#pybind11==2.10.0
-#inflection==0.5.1
 event-channel==0.4.3
-#pytz==2022.2.1
 
 # IO extensions
 pigpio==1.78


### PR DESCRIPTION
Removed the following requirements, no more needed:
itsdangerous==2.1.2
jsonschema==4.15.0
Markdown==3.4.1
MarkupSafe==2.1.1
pyyaml==6.0
requests==2.28.1
swagger-spec-validator==2.7.6
urllib3==1.26.12
certifi==2022.5.18.1
absl-py==1.2.0
chardet==3.0.4
click==8.1.3
clickclick==20.10.2
gast==0.5.3
idna==3.3
pybind11==2.10.0
inflection==0.5.1
pytz==2022.2.1

